### PR TITLE
fix: make sure we generate a unique user secret id

### DIFF
--- a/content/Framework Project/.template.config/template.json
+++ b/content/Framework Project/.template.config/template.json
@@ -112,6 +112,11 @@
     }
   ],
   "symbols": {
+    "userSecretId": {
+      "type": "generated",
+      "generator": "guid",
+      "replaces": "9424fe73-f4dd-4d92-a137-deea3d0f1c46"
+    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "host:HostIdentifier"


### PR DESCRIPTION
Currently, all projects generated through the template have the same User Secret ID:
`<UserSecretsId>9424fe73-f4dd-4d92-a137-deea3d0f1c46</UserSecretsId>`. This is problematic because we would unknowingly use the same secrets for multiple projects.

This PR makes sure we generate a new, unique guid for every generated project